### PR TITLE
fix(docs): clarify the description of the checking logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,24 +61,23 @@ The translated strings are checked, one by one, for:
   * Unclosed elements (e.g., `<span>This span is not closed`)
   * Elements closed in the wrong order.
     * (e.g., `<a><span>closed out of order</a></span>`)
-1. Unexpected tags
+1. Unexpected tags. Tag names that are not used in the source `.pot` files may not be present in the translated `.po` files. For instance:
   * If the source `.pot` files contain only `a` and `span` tags, the translated files:
       1. Can contain 0 or more `a` and `span` tags.
       1. All other tags cause an error.
-1. Unexpected tag attributes
-  * If the source `.pot` files contain `<a href="/signin" target="_blank">`,
-      `<button id="logout">`, and `<div>...`, the translated files:
-      1. Can have 0 or more `a` elements, which can have 0, 1 or both `href` and `target` attributes.
-      1. Can have 0 or more `button` elements, which can 0 or 1 `id` attribute.
+1. Unexpected attributes. Attributes that are not used on a type of element in the source `.pot` files may not be present on instances of that element type in the translated `.po` files. For instance:
+  * If the source `.pot` files contain `<a href="..." target="...">`,
+      `<button id="...">` and `<button class="...">`, the translated files:
+      1. Can have either, both or neither of the `href` and `target` attributes on each `a` element.
+      1. Can have either, both or neither of the `id` and `class` attributes on each `button` element.
       1. All other attributes will cause an error.
-1. Unexpected tag attribute values
+1. Unexpected attribute values. Attribute values that are not used on a type of element in the source `.pot` files may not be present on instances of that element type in the translated `.po` files. For instance:
   * If the source `.pot` files contain `<a href="/signin" target="_blank">`
-      and `<button id="logout">`, and `<div>...`, the translated files:
-      1. Can have 0 or more `a` tags, which can have 0, 1 or both `href="/signin""` or
-         `target="_blank"` attributes.
-      1. Can have 0 or more `button` elements, which can have 0 or 1 `id="logout"` attribute.
-      1. Can have 0 or more `div` elements, which can have no attributes.
-      1. All other attributes or attribute values cause an error.
+      and `<button id="logout">`, the translated files:
+      1. Can only have the value `/signin` for `href` attributes.
+      1. Can only have the value `_blank` for `target` attributes.
+      1. Can only have the value `logout` for `id` attributes.
+      1. All other attribute values cause an error.
 
 The target translation checks are very coarse.
 
@@ -89,7 +88,7 @@ If the source `.pot` file contains two `a` elements, one
 with `id="first-anchor"` and another with `id="second-anchor"`, _any_ translated
 string could contain an `a` element with either `id`.
 
-All translated strings are assumed to be independent items, anduare checked
+All translated strings are assumed to be independent items, and are checked
 individually. Quotes that surround attribute values are not checked, as long
 as the tag correctly closes and the attribute value matches an expected value,
 the value is accepted.


### PR DESCRIPTION
@shane-tomlinson, I found some of the readme a bit tricky to parse so here is an attempt to improve it, hope you don't mind. Feel free to ignore, I don't know whether this makes things better or not.

The bits I found confusing were the descriptions of the checking logic:

* It wasn't clear that you were using `<a>`, `<span>` and so on as examples at first. I thought the descriptions were literally just about those specific tags.

* Repeating the `Can have ... elements` in the points about attributes/values muddied the waters for me, because the element bit had already been covered. Ditto chucking the `<div>` element in to the same points.

So, my changes are:

1. To add a general description for the unexpected tags/attributes/values points. And then to prefix the example bullets with `For instance:`.

2. To try and make each of those points self-contained, assuming knowledge of definitions from each of the preceding points. 

3. And there was also one typo, which I took the opportunity to fix.