### PR TITLE
fix(lint): Ensure proper nesting of open/close tag brackets.

### DIFF
--- a/lib/check-translation.js
+++ b/lib/check-translation.js
@@ -53,7 +53,7 @@ function CheckTranslation(translation, expectedTagsData, callback) {
   this._expectedTagsData = expectedTagsData;
   this._callback = callback;
 
-  this._openTagStack = [];
+  this._openElementStack = [];
 
   try {
     this._errorIfUnmatchedBrackets();
@@ -88,7 +88,7 @@ function CheckTranslation(translation, expectedTagsData, callback) {
   // any outstanding tags that weren't closed?
   if (! this._done) {
     try {
-      this._errorIfTagStillOpen();
+      this._errorIfElementStillOpen();
     } catch (err) {
       this._finish(err);
       return;
@@ -104,10 +104,10 @@ CheckTranslation.prototype = {
   constructor: CheckTranslation,
 
   /**
-   * Tags that are currently open. If tags are closed out
+   * Elements that are currently open. If elements are closed out
    * of order or left open, then error.
    */
-  _openTagStack: null,
+  _openElementStack: null,
 
   _done: false,
   _finish: function (status) {
@@ -120,25 +120,34 @@ CheckTranslation.prototype = {
     this._callback(status);
   },
 
-  _countOccurrances: function (needle, haystack) {
-    var regExp = new RegExp(needle, 'g');
-    var found; //eslint-disable-line no-unused-vars
-
-    var count = 0;
-    while ((found = regExp.exec(haystack)) !== null) {
-      count++;
-    }
-
-    return count;
-  },
-
   _errorIfUnmatchedBrackets: function () {
     var translation = this._translation;
 
-    var openTagCount = this._countOccurrances('<', translation);
-    var closeTagCount = this._countOccurrances('>', translation);
+    // walk through each character of the translation. On an opening bracket,
+    // ensure another tag is not currently open. On a closing bracket, ensure
+    // a tag is open. After all characters are checked, ensure no tags are left
+    // open.
 
-    if (openTagCount !== closeTagCount) {
+    var isTagOpen = false;
+    for (var i = 0; i < translation.length; ++i) {
+      var char = translation.charAt(i);
+      if (char === '<') {
+        if (isTagOpen) {
+          // tag already open, fail.
+          throw new MalformedHTMLError(translation);
+        }
+        isTagOpen = true;
+      } else if (char === '>') {
+        if (isTagOpen === false) {
+          // tag already closed, fail.
+          throw new MalformedHTMLError(translation);
+        }
+        isTagOpen = false;
+      }
+    }
+
+    // Is a tag left open?
+    if (isTagOpen) {
       throw new MalformedHTMLError(translation);
     }
   },
@@ -176,14 +185,14 @@ CheckTranslation.prototype = {
      * Check the tag being closed against the most recently opened
      * tag. If they are not the same, invalid HTML.
      */
-    var lastOpenedTag = this._openTagStack.pop();
-    if (closeTag !== lastOpenedTag) {
+    var lastOpenedElement = this._openElementStack.pop();
+    if (closeTag !== lastOpenedElement) {
       throw new MalformedHTMLError(this._translation);
     }
   },
 
-  _errorIfTagStillOpen: function () {
-    if (this._openTagStack.length) {
+  _errorIfElementStillOpen: function () {
+    if (this._openElementStack.length) {
       throw new MalformedHTMLError(this._translation);
     }
   },
@@ -205,7 +214,7 @@ CheckTranslation.prototype = {
       return;
     }
 
-    this._openTagStack.push(tagName);
+    this._openElementStack.push(tagName);
 
     try {
       this._errorIfUnexpectedTag(tagName);

--- a/test/check-translation-test.js
+++ b/test/check-translation-test.js
@@ -157,7 +157,7 @@ exports.check_translations = {
 
   'malformed html - no opening or closing tag name': function (test) {
     checkTranslation(
-      '<>no opening tag name</>',
+      '<>no opening or closing tag name</>',
       expectedTagData,
       function (err) {
         test.ok(err instanceof MalformedHTMLError);
@@ -221,6 +221,28 @@ exports.check_translations = {
     );
   },
 
+  'malformed html - matched brackets without tags': function (test) {
+    checkTranslation(
+      '> <',
+      expectedTagData,
+      function (err) {
+        test.ok(err instanceof MalformedHTMLError);
+        test.done();
+      }
+    );
+  },
+
+  'malformed html - unmatched closing bracket after tag': function (test) {
+    checkTranslation(
+      '<a> >',
+      expectedTagData,
+      function (err) {
+        test.ok(err instanceof MalformedHTMLError);
+        test.done();
+      }
+    );
+  },
+
   'malformed html - nested tags closed out of order': function (test) {
     checkTranslation(
       '<span><a href="/signin">Signin</span></a>',
@@ -230,8 +252,6 @@ exports.check_translations = {
         test.done();
       }
     );
-  },
-
-
+  }
 };
 


### PR DESCRIPTION
`> <` is now considered bad HTML.

fixes #2 

@rfk - r?